### PR TITLE
Updated home route to redirect to blocks

### DIFF
--- a/src/common/components/home.js
+++ b/src/common/components/home.js
@@ -1,21 +1,19 @@
 import React from "react";
-import { Link } from "react-router-dom";
+
+import historyShape from "../shapes/historyShape";
 
 export default class Home extends React.Component {
   static displayName = "Home";
 
+  static propTypes = {
+    history: historyShape.isRequired
+  };
+
+  componentDidMount = () => {
+    this.props.history.replace("/blocks");
+  }
+
   render = () => {
-    return (
-      <div className="home-component">
-        <h2>Welcome</h2>
-        <p>
-          Coming soon: interesting charts about blocks, transactions, addresses, etc.
-        </p>
-        <p>
-          For now, explore the latest <Link to="/blocks">blocks</Link> and{" "}
-          <Link to="/transactions">transactions</Link>.
-        </p>
-      </div>
-    );
+    return null;
   }
 }


### PR DESCRIPTION
To prevent bouncing from the barren homepage (until #24 can be worked on), this will temporarily redirect the root path to the blocks path.